### PR TITLE
Add Firebase client components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# detailing-app
+# Detailing App
+
+This repository contains simple React components that use Firebase Firestore to manage detailing clients.
+
+## Components
+
+- `src/clients/AddClient.js` – form for creating a new client.
+- `src/clients/ClientsList.js` – lists existing clients and allows deleting them.
+
+Firestore collection `clients` stores documents with the following fields:
+
+- `name`
+- `phone`
+- `car`
+- `registration`
+- `visitDate`
+- `services`
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install react firebase
+   ```
+2. Configure Firebase credentials in environment variables:
+   - `REACT_APP_FIREBASE_API_KEY`
+   - `REACT_APP_FIREBASE_AUTH_DOMAIN`
+   - `REACT_APP_FIREBASE_PROJECT_ID`
+3. Import the components in your React application:
+   ```jsx
+   import AddClient from './clients/AddClient';
+   import ClientsList from './clients/ClientsList';
+   ```
+4. Render them where needed:
+   ```jsx
+   <AddClient />
+   <ClientsList />
+   ```
+
+The components will perform CRUD operations on the Firestore `clients` collection.

--- a/src/clients/AddClient.js
+++ b/src/clients/AddClient.js
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+import { addClient } from "./clientService";
+
+const initial = {
+  name: "",
+  phone: "",
+  car: "",
+  registration: "",
+  visitDate: "",
+  services: "",
+};
+
+export default function AddClient() {
+  const [form, setForm] = useState(initial);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await addClient(form);
+    setForm(initial);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Add Client</h2>
+      {Object.keys(initial).map((k) => (
+        <div key={k}>
+          <label>
+            {k}
+            <input
+              name={k}
+              value={form[k]}
+              onChange={handleChange}
+            />
+          </label>
+        </div>
+      ))}
+      <button type="submit">Save</button>
+    </form>
+  );
+}

--- a/src/clients/ClientsList.js
+++ b/src/clients/ClientsList.js
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from "react";
+import { getClients, deleteClient } from "./clientService";
+
+export default function ClientsList() {
+  const [clients, setClients] = useState([]);
+
+  const load = async () => {
+    const data = await getClients();
+    setClients(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleDelete = async (id) => {
+    await deleteClient(id);
+    load();
+  };
+
+  return (
+    <div>
+      <h2>Clients</h2>
+      <ul>
+        {clients.map((c) => (
+          <li key={c.id}>
+            {c.name} - {c.car} - {c.phone}
+            <button onClick={() => handleDelete(c.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/clients/clientService.js
+++ b/src/clients/clientService.js
@@ -1,0 +1,30 @@
+import {
+  collection,
+  addDoc,
+  getDocs,
+  doc,
+  updateDoc,
+  deleteDoc,
+} from "firebase/firestore";
+import { db } from "../firebase";
+
+const clientsCol = collection(db, "clients");
+
+export const addClient = async (client) => {
+  return addDoc(clientsCol, client);
+};
+
+export const getClients = async () => {
+  const snapshot = await getDocs(clientsCol);
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+};
+
+export const updateClient = async (id, data) => {
+  const ref = doc(db, "clients", id);
+  return updateDoc(ref, data);
+};
+
+export const deleteClient = async (id) => {
+  const ref = doc(db, "clients", id);
+  return deleteDoc(ref);
+};

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,0 +1,11 @@
+import { initializeApp } from "firebase/app";
+import { getFirestore } from "firebase/firestore";
+
+const firebaseConfig = {
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);


### PR DESCRIPTION
## Summary
- add Firestore setup
- add CRUD service for the `clients` collection
- add `AddClient` and `ClientsList` components
- document setup and usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842155efac0832b8f0c3f965f846eb1