### PR TITLE
Add quotation form and PDF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # detailing-app
+
+This repository contains a simple quotation form for a vehicle detailing service. Open `src/quotation/index.html` in a browser to fill in client and vehicle details, specify the service scope, and generate a downloadable PDF quotation using **jsPDF**.

--- a/src/quotation/index.html
+++ b/src/quotation/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Quotation Form</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    form { max-width: 600px; }
+    label { display: block; margin-top: 10px; }
+    input, textarea { width: 100%; padding: 6px; margin-top: 4px; box-sizing: border-box; }
+    button { margin-top: 20px; padding: 10px 20px; }
+  </style>
+</head>
+<body>
+  <h1>Service Quotation</h1>
+  <form id="quoteForm">
+    <fieldset>
+      <legend>Client Details</legend>
+      <label>Name <input type="text" id="clientName" required></label>
+      <label>Email <input type="email" id="clientEmail" required></label>
+      <label>Phone <input type="tel" id="clientPhone" required></label>
+    </fieldset>
+    <fieldset>
+      <legend>Vehicle Information</legend>
+      <label>Make <input type="text" id="vehicleMake" required></label>
+      <label>Model <input type="text" id="vehicleModel" required></label>
+      <label>Year <input type="number" id="vehicleYear" required></label>
+    </fieldset>
+    <fieldset>
+      <legend>Service Scope</legend>
+      <textarea id="serviceScope" rows="4" required></textarea>
+    </fieldset>
+    <fieldset>
+      <legend>Proposed Dates</legend>
+      <label>Preferred Date <input type="date" id="preferredDate" required></label>
+    </fieldset>
+    <button type="button" id="generatePdf">Generate PDF</button>
+  </form>
+
+  <script>
+    document.getElementById('generatePdf').addEventListener('click', () => {
+      const {{ jsPDF }} = window.jspdf;
+      const doc = new jsPDF();
+      const name = document.getElementById('clientName').value;
+      const email = document.getElementById('clientEmail').value;
+      const phone = document.getElementById('clientPhone').value;
+      const make = document.getElementById('vehicleMake').value;
+      const model = document.getElementById('vehicleModel').value;
+      const year = document.getElementById('vehicleYear').value;
+      const scope = document.getElementById('serviceScope').value;
+      const date = document.getElementById('preferredDate').value;
+
+      let y = 10;
+      doc.setFontSize(16);
+      doc.text('Service Quotation', 10, y);
+      y += 10;
+      doc.setFontSize(12);
+
+      doc.text('Client Details:', 10, y); y += 6;
+      doc.text(`Name: ${name}`, 10, y); y += 6;
+      doc.text(`Email: ${email}`, 10, y); y += 6;
+      doc.text(`Phone: ${phone}`, 10, y); y += 10;
+
+      doc.text('Vehicle Information:', 10, y); y += 6;
+      doc.text(`Make: ${make}`, 10, y); y += 6;
+      doc.text(`Model: ${model}`, 10, y); y += 6;
+      doc.text(`Year: ${year}`, 10, y); y += 10;
+
+      doc.text('Service Scope:', 10, y); y += 6;
+      doc.text(scope, 10, y); y += 10;
+
+      doc.text('Proposed Date:', 10, y); y += 6;
+      doc.text(date, 10, y);
+
+      doc.save('quotation.pdf');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a quotation form in `src/quotation/index.html`
- use jsPDF to generate a downloadable quotation PDF
- update README with instructions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842173c8554832b9b4a8f613eb566bd