### PR TITLE
Add basic calendar with JSON export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # detailing-app
+
+This project includes a simple calendar module located in `src/calendar/`.
+Open `src/calendar/index.html` in a browser to manage open days and services.
+Use the **Export to dates.json** button to download the calendar data.

--- a/src/calendar/index.html
+++ b/src/calendar/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Calendar</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div id="calendar-controls">
+<label for="month">Month:</label>
+<select id="month"></select>
+<label for="year">Year:</label>
+<select id="year"></select>
+</div>
+<div id="calendar"></div>
+<div id="day-editor" class="hidden">
+<h3 id="editor-date"></h3>
+<label>Description: <input type="text" id="desc" /></label>
+<label>Icons (comma separated): <input type="text" id="icons" /></label>
+<label>Services (comma separated): <input type="text" id="services" /></label>
+<button id="save-day">Save</button>
+<button id="close-editor">Close</button>
+</div>
+<button id="export">Export to dates.json</button>
+<script src="script.js"></script>
+</body>
+</html>

--- a/src/calendar/script.js
+++ b/src/calendar/script.js
@@ -1,0 +1,96 @@
+const monthSelect = document.getElementById('month');
+const yearSelect = document.getElementById('year');
+const calendarEl = document.getElementById('calendar');
+const dayEditor = document.getElementById('day-editor');
+const editorDate = document.getElementById('editor-date');
+const descInput = document.getElementById('desc');
+const iconsInput = document.getElementById('icons');
+const servicesInput = document.getElementById('services');
+const saveDayBtn = document.getElementById('save-day');
+const closeEditorBtn = document.getElementById('close-editor');
+const exportBtn = document.getElementById('export');
+
+const calendarData = {};
+
+function populateSelectors() {
+    for (let m = 0; m < 12; m++) {
+        const opt = document.createElement('option');
+        opt.value = m;
+        opt.textContent = new Date(2020, m, 1).toLocaleString('default', { month: 'long' });
+        monthSelect.appendChild(opt);
+    }
+    const currentYear = new Date().getFullYear();
+    for (let y = currentYear - 5; y <= currentYear + 5; y++) {
+        const opt = document.createElement('option');
+        opt.value = y;
+        opt.textContent = y;
+        yearSelect.appendChild(opt);
+    }
+    monthSelect.value = new Date().getMonth();
+    yearSelect.value = currentYear;
+}
+
+function buildCalendar() {
+    calendarEl.innerHTML = '';
+    const year = parseInt(yearSelect.value, 10);
+    const month = parseInt(monthSelect.value, 10);
+    const firstDay = new Date(year, month, 1);
+    const lastDay = new Date(year, month + 1, 0);
+    const startDayOfWeek = firstDay.getDay();
+
+    for (let i = 0; i < startDayOfWeek; i++) {
+        const empty = document.createElement('div');
+        calendarEl.appendChild(empty);
+    }
+
+    for (let d = 1; d <= lastDay.getDate(); d++) {
+        const cell = document.createElement('div');
+        const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+        cell.className = 'day';
+        cell.textContent = d;
+        cell.dataset.date = dateStr;
+        if (calendarData[dateStr]) {
+            cell.classList.add('open');
+        }
+        cell.addEventListener('click', () => editDay(dateStr));
+        calendarEl.appendChild(cell);
+    }
+}
+
+function editDay(dateStr) {
+    editorDate.textContent = dateStr;
+    const data = calendarData[dateStr] || { desc: '', icons: [], services: [] };
+    descInput.value = data.desc;
+    iconsInput.value = data.icons.join(',');
+    servicesInput.value = data.services.join(',');
+    dayEditor.classList.remove('hidden');
+    saveDayBtn.onclick = () => {
+        const desc = descInput.value.trim();
+        const icons = iconsInput.value.split(',').map(s => s.trim()).filter(Boolean);
+        const services = servicesInput.value.split(',').map(s => s.trim()).filter(Boolean);
+        if (desc || icons.length || services.length) {
+            calendarData[dateStr] = { desc, icons, services };
+        } else {
+            delete calendarData[dateStr];
+        }
+        dayEditor.classList.add('hidden');
+        buildCalendar();
+    };
+}
+
+closeEditorBtn.addEventListener('click', () => dayEditor.classList.add('hidden'));
+monthSelect.addEventListener('change', buildCalendar);
+yearSelect.addEventListener('change', buildCalendar);
+exportBtn.addEventListener('click', () => {
+    const dataStr = JSON.stringify(calendarData, null, 2);
+    const blob = new Blob([dataStr], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'dates.json';
+    a.click();
+    URL.revokeObjectURL(url);
+});
+
+populateSelectors();
+buildCalendar();

--- a/src/calendar/styles.css
+++ b/src/calendar/styles.css
@@ -1,0 +1,29 @@
+body {
+    font-family: Arial, sans-serif;
+}
+#calendar-controls {
+    margin-bottom: 10px;
+}
+#calendar {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 5px;
+}
+.day {
+    border: 1px solid #ccc;
+    padding: 5px;
+    min-height: 60px;
+    position: relative;
+    cursor: pointer;
+}
+.day.open {
+    background-color: #e0ffe0;
+}
+.hidden {
+    display: none;
+}
+#day-editor {
+    border: 1px solid #999;
+    padding: 10px;
+    margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- add a simple browser-based calendar in `src/calendar`
- allow selecting days and entering descriptions, icons, and services
- export stored entries to `dates.json`
- update README with basic usage instructions

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6842180cf91c832ba348c0257d8c5ccf